### PR TITLE
add config.image.exposedPorts

### DIFF
--- a/lib/make-image.nix
+++ b/lib/make-image.nix
@@ -95,6 +95,7 @@ in containerBuilder {
   config = {
     EntryPoint = eval.config.image.entryPoint;
     Env = mapAttrsToList (n: v: "${n}=${v}") eval.config.image.env;
+    ExposedPorts = eval.config.image.exposedPorts;
   };
 }
 //

--- a/modules/image.nix
+++ b/modules/image.nix
@@ -42,6 +42,13 @@ in
           Entry point command list
         '';
       };
+      exposedPorts = mkOption {
+        type = types.attrs;
+        default = {};
+        description = ''
+          Ports exposed by the container
+        '';
+      };
       from = mkOption {
         type = types.nullOr types.package;
         default = null;

--- a/overlay.nix
+++ b/overlay.nix
@@ -16,6 +16,7 @@ let
     dockerImages = {
       nix = super.callPackage ./tests/nix.nix { };
       from = super.callPackage ./tests/from.nix { };
+      exposedPorts = super.callPackage ./tests/exposed-ports.nix { };
       nginx = super.callPackage ./tests/nginx.nix { };
       env = super.callPackage ./tests/env.nix { };
       systemd = super.callPackage ./tests/systemd.nix { };

--- a/tests/exposed-ports.nix
+++ b/tests/exposed-ports.nix
@@ -1,0 +1,21 @@
+{ pkgs, lib, dockerTools, coreutils }:
+
+let
+  image = lib.makeImage {
+    config = {
+      image = {
+        name = "exposed-ports";
+        exposedPorts = { "5000/tcp" = {}; };
+      };
+      environment.systemPackages = [ coreutils ];
+    };
+  };
+in lib.makeContainerTest {
+  inherit image;
+  testScript = ''
+    $machine->waitForUnit("docker.service");
+    $machine->succeed("docker load -i ${image}");
+    $machine->succeed("docker run -d -P --name exposed-ports ${lib.imageRef image} sleep 10m");
+    $machine->succeed("docker port exposed-ports | grep '5000/tcp -> 0.0.0.0'");
+  '';
+}


### PR DESCRIPTION
It is useful to run containers with the -P option, this option map containers ports to random ports (in the range 32000) on the host.

Example of the syntax :
```
lib.makeImage { 
  config = {
    image.exposedPorts = {"5000/tcp" = {};};
...
  };
}
```

Expected behaviour :
```
# docker run -P --name foo bar:latest
# docker port foo
5000/tcp -> 0.0.0.0:32771
```